### PR TITLE
Breaking september - add default class

### DIFF
--- a/scripts/default.js
+++ b/scripts/default.js
@@ -133,14 +133,17 @@ function decorateForm () {
 }
 
 
-function wrapSections(element, appendClass) {
+function wrapSections(element) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
-        if (appendClass) {
-            $div.classList.add(appendClass);
-        }
+    });
+}
+
+function addDefaultClass(element) {
+    document.querySelectorAll(element).forEach(($div) => {
+        $div.classList.add('default');
     });
 }
 
@@ -283,7 +286,8 @@ function paramHelper() {
 async function decoratePage() {
     turnListSectionIntoCards();
     decorateTables();
-    wrapSections('main>div', 'default');
+    wrapSections('main>div');
+    addDefaultClass('main>div');
     decorateForm();
     await loadLocalHeader();
     wrapSections('header>div');

--- a/scripts/default.js
+++ b/scripts/default.js
@@ -287,7 +287,7 @@ async function decoratePage() {
     turnListSectionIntoCards();
     decorateTables();
     wrapSections('main>div');
-    addDefaultClass('main>div');
+    addDefaultClass('main>.section-wrapper>div');
     decorateForm();
     await loadLocalHeader();
     wrapSections('header>div');

--- a/scripts/default.js
+++ b/scripts/default.js
@@ -133,11 +133,14 @@ function decorateForm () {
 }
 
 
-function wrapSections(element) {
+function wrapSections(element, appendClass) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
+        if (appendClass) {
+            $div.classList.add(appendClass);
+        }
     });
 }
 
@@ -280,7 +283,7 @@ function paramHelper() {
 async function decoratePage() {
     turnListSectionIntoCards();
     decorateTables();
-    wrapSections('main>div');
+    wrapSections('main>div', 'default');
     decorateForm();
     await loadLocalHeader();
     wrapSections('header>div');

--- a/scripts/ete.js
+++ b/scripts/ete.js
@@ -374,7 +374,7 @@ async function decoratePage() {
 
   window.pages.decorated = true;
   wrapSections(".home > main > div");
-  addDefaultClass('main>div');
+  addDefaultClass('main>.section-wrapper>div');
   await cleanUpBio();
   appearMain();
   externalLinks("main .section-wrapper:last-of-type")

--- a/scripts/ete.js
+++ b/scripts/ete.js
@@ -17,14 +17,17 @@ function getThumbnail(step) {
   return thumbnail;
 }
 
-function wrapSections(element, appendClass) {
+function wrapSections(element) {
   document.querySelectorAll(element).forEach(($div) => {
     const $wrapper = createTag("div", { class: "section-wrapper" });
     $div.parentNode.appendChild($wrapper);
     $wrapper.appendChild($div);
-    if (appendClass) {
-      $div.classList.add(appendClass);
-  }
+  });
+}
+
+function addDefaultClass(element) {
+  document.querySelectorAll(element).forEach(($div) => {
+    $div.classList.add('default');
   });
 }
 
@@ -370,7 +373,8 @@ async function decoratePage() {
   }
 
   window.pages.decorated = true;
-  wrapSections(".home > main > div", "default");
+  wrapSections(".home > main > div");
+  addDefaultClass('main>div');
   await cleanUpBio();
   appearMain();
   externalLinks("main .section-wrapper:last-of-type")

--- a/scripts/ete.js
+++ b/scripts/ete.js
@@ -375,6 +375,7 @@ async function decoratePage() {
   window.pages.decorated = true;
   wrapSections(".home > main > div");
   addDefaultClass('main>.section-wrapper>div');
+  addDefaultClass('.step>main>div');
   await cleanUpBio();
   appearMain();
   externalLinks("main .section-wrapper:last-of-type")

--- a/scripts/ete.js
+++ b/scripts/ete.js
@@ -17,11 +17,14 @@ function getThumbnail(step) {
   return thumbnail;
 }
 
-function wrapSections(element) {
+function wrapSections(element, appendClass) {
   document.querySelectorAll(element).forEach(($div) => {
     const $wrapper = createTag("div", { class: "section-wrapper" });
     $div.parentNode.appendChild($wrapper);
     $wrapper.appendChild($div);
+    if (appendClass) {
+      $div.classList.add(appendClass);
+  }
   });
 }
 
@@ -367,7 +370,7 @@ async function decoratePage() {
   }
 
   window.pages.decorated = true;
-  wrapSections(".home > main > div");
+  wrapSections(".home > main > div", "default");
   await cleanUpBio();
   appearMain();
   externalLinks("main .section-wrapper:last-of-type")

--- a/scripts/in-app.js
+++ b/scripts/in-app.js
@@ -1,8 +1,11 @@
-function wrapSections(element) {
+function wrapSections(element, appendClass) {
   document.querySelectorAll(element).forEach(($div) => {
       const $wrapper=createTag('div', { class: 'section-wrapper'});
       $div.parentNode.appendChild($wrapper);
       $wrapper.appendChild($div);
+      if (appendClass) {
+        $div.classList.add(appendClass);
+    }
   });
 }
 
@@ -94,7 +97,7 @@ function paramHelper() {
 
 async function decoratePage() {
   decorateTables();
-  wrapSections('main>div');
+  wrapSections('main>div', 'default');
   await loadLocalHeader();
   wrapSections('header>div');
   wrapSections('footer>div');

--- a/scripts/in-app.js
+++ b/scripts/in-app.js
@@ -1,12 +1,15 @@
-function wrapSections(element, appendClass) {
+function wrapSections(element) {
   document.querySelectorAll(element).forEach(($div) => {
       const $wrapper=createTag('div', { class: 'section-wrapper'});
       $div.parentNode.appendChild($wrapper);
       $wrapper.appendChild($div);
-      if (appendClass) {
-        $div.classList.add(appendClass);
-    }
   });
+}
+
+function addDefaultClass(element) {
+    document.querySelectorAll(element).forEach(($div) => {
+        $div.classList.add('default');
+    });
 }
 
 
@@ -97,7 +100,8 @@ function paramHelper() {
 
 async function decoratePage() {
   decorateTables();
-  wrapSections('main>div', 'default');
+  wrapSections('main>div');
+  addDefaultClass('main>div');
   await loadLocalHeader();
   wrapSections('header>div');
   wrapSections('footer>div');

--- a/scripts/in-app.js
+++ b/scripts/in-app.js
@@ -101,7 +101,7 @@ function paramHelper() {
 async function decoratePage() {
   decorateTables();
   wrapSections('main>div');
-  addDefaultClass('main>div');
+  addDefaultClass('main>.section-wrapper>div');
   await loadLocalHeader();
   wrapSections('header>div');
   wrapSections('footer>div');

--- a/scripts/max.js
+++ b/scripts/max.js
@@ -110,11 +110,14 @@ function decorateForm () {
 }
 
 
-function wrapSections(element) {
+function wrapSections(element, appendClass) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
+        if (appendClass) {
+            $div.classList.add(appendClass);
+        }
     });
 }
 
@@ -265,7 +268,7 @@ async function decoratePage() {
     unwrapEmbeds();
     turnListSectionIntoCards();
     decorateTables();
-    wrapSections('main>div');
+    wrapSections('main>div', 'default');
     decorateForm();
     await loadLocalHeader();
     wrapSections('header>div');

--- a/scripts/max.js
+++ b/scripts/max.js
@@ -272,7 +272,7 @@ async function decoratePage() {
     turnListSectionIntoCards();
     decorateTables();
     wrapSections('main>div');
-    addDefaultClass('main>div');
+    addDefaultClass('main>.section-wrapper>div');
     decorateForm();
     await loadLocalHeader();
     wrapSections('header>div');

--- a/scripts/max.js
+++ b/scripts/max.js
@@ -110,14 +110,17 @@ function decorateForm () {
 }
 
 
-function wrapSections(element, appendClass) {
+function wrapSections(element) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
-        if (appendClass) {
-            $div.classList.add(appendClass);
-        }
+    });
+}
+
+function addDefaultClass(element) {
+    document.querySelectorAll(element).forEach(($div) => {
+        $div.classList.add('default');
     });
 }
 
@@ -268,7 +271,8 @@ async function decoratePage() {
     unwrapEmbeds();
     turnListSectionIntoCards();
     decorateTables();
-    wrapSections('main>div', 'default');
+    wrapSections('main>div');
+    addDefaultClass('main>div');
     decorateForm();
     await loadLocalHeader();
     wrapSections('header>div');

--- a/scripts/step-by-step.js
+++ b/scripts/step-by-step.js
@@ -199,11 +199,14 @@ async function decorateStep() {
 
 }
 
-function wrapSections(element) {
+function wrapSections(element, appendClass) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
+        if (appendClass) {
+            $div.classList.add(appendClass);
+        }
     });
 }
 

--- a/scripts/step-by-step.js
+++ b/scripts/step-by-step.js
@@ -199,18 +199,19 @@ async function decorateStep() {
 
 }
 
-function wrapSections(element, appendClass) {
+function wrapSections(element) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
-        if (appendClass) {
-            $div.classList.add(appendClass);
-        }
     });
 }
 
-
+function addDefaultClass(element) {
+    document.querySelectorAll(element).forEach(($div) => {
+        $div.classList.add('default');
+    });
+}
 
 async function decorateHome() {
     document.body.classList.add('home');
@@ -231,6 +232,7 @@ async function decoratePage() {
     externalLinks('header');
     externalLinks('footer');
     wrapSections('header>div');
+    addDefaultClass('main>div');
     // nav style/dropdown
     addNavCarrot();
 

--- a/scripts/twp3.js
+++ b/scripts/twp3.js
@@ -222,7 +222,7 @@ async function decorateStep() {
 
 }
 
-function wrapSections(element, appendClass) {
+function wrapSections(element) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
@@ -230,6 +230,12 @@ function wrapSections(element, appendClass) {
         if (appendClass) {
             $div.classList.add(appendClass);
         }
+    });
+}
+
+function addDefaultClass(element) {
+    document.querySelectorAll(element).forEach(($div) => {
+        $div.classList.add('default');
     });
 }
 
@@ -254,6 +260,7 @@ async function decoratePage() {
     externalLinks('header');
     externalLinks('footer');
     wrapSections('header>div');
+    addDefaultClass('main>div');
     // nav style/dropdown
     addNavCarrot();
 

--- a/scripts/twp3.js
+++ b/scripts/twp3.js
@@ -222,11 +222,14 @@ async function decorateStep() {
 
 }
 
-function wrapSections(element) {
+function wrapSections(element, appendClass) {
     document.querySelectorAll(element).forEach(($div) => {
         const $wrapper=createTag('div', { class: 'section-wrapper'});
         $div.parentNode.appendChild($wrapper);
         $wrapper.appendChild($div);
+        if (appendClass) {
+            $div.classList.add(appendClass);
+        }
     });
 }
 


### PR DESCRIPTION
The `default` css class has been removed from the default helix-pages css output (see https://github.com/adobe/helix-pages/issues/403).

It is extensively used in the project. 2 options:
1. remove the `.default` class usage from all css and js files
2. add the css class on load to not change the css

2 requires quite some refactoring and even some css logic rethinking (some selectors become stronger). To minimise the risk and propose a quick fix, I implemented 2. 

