### PR TITLE
adds click handler and pointer style to header images

### DIFF
--- a/templates/stock-advocates/stock-advocates.css
+++ b/templates/stock-advocates/stock-advocates.css
@@ -266,6 +266,10 @@ header .icon.icon-stock-logo {
   }
 }
 
+.handsy {
+  cursor: pointer;
+}
+
 /* hero section */
 
 .hero-section {

--- a/templates/stock-advocates/stock-advocates.js
+++ b/templates/stock-advocates/stock-advocates.js
@@ -303,9 +303,6 @@ function decorateTables() {
 
   }
 
-  function navigateHome() {
-    
-  }
 
   function decorateContactUs() {
     const $contactus=document.getElementById('contact-us');

--- a/templates/stock-advocates/stock-advocates.js
+++ b/templates/stock-advocates/stock-advocates.js
@@ -280,6 +280,13 @@ function decorateTables() {
     const $hamburger=$header.children[2];
 
     $logo.classList.add('logo');
+    $logo.classList.add('handsy');
+
+    $logo.addEventListener("click", (() => { 
+      // don't want to wrap with a tag, too many styles using children[0]
+      // this won't work if we add more subs, takes us back to /stock/en/
+      window.location.pathname = window.location.pathname.split("/").slice(0,-2).join("/") + "/";
+    }));
     $menu.classList.add('menu');
     $hamburger.classList.add('hamburger');
 
@@ -294,6 +301,10 @@ function decorateTables() {
     })
     decorateLogo();
 
+  }
+
+  function navigateHome() {
+    
   }
 
   function decorateContactUs() {
@@ -312,8 +323,13 @@ function decorateTables() {
     const $hero=document.querySelector('.hero-carousel');
     if (!$hero) {
       const $header=document.querySelector('header');
-      const $asaLogoDiv=createTag('div', {class: 'asa-logo'});
+      const $asaLogoDiv=createTag('div', {class: 'asa-logo handsy'});
       $asaLogoDiv.innerHTML=`<img src="/templates/stock-advocates/advocates_logo_small.svg">`;
+      // don't want to wrap with a tag, too many style selectors may break - kk
+      $asaLogoDiv.addEventListener("click", (() => { 
+        // this won't work if we add more sub folders
+        window.location.pathname = window.location.pathname.split("/").slice(0,-1).join("/") + "/";
+      }));
       $header.append($asaLogoDiv);
     }
   }


### PR DESCRIPTION
## Description

I didn't want to do this by adding an <a> tag at runtime, because there is lots of code that uses like header.children[0] and expects the img tag there.

Instead, I added an onclick event and a style to show a cursor. For the middle "Adobe Stock Advocates" logo, I had it link to the index of the current directory (using a calculation on window.location.pathname)

I'm not sure what to link the home page to, because there is /stock/en/ but there is nothing there in adobe pages, ie this:

https://pages--adobe.hlx.page/stock/en/

returns a 404, if I remove the language

https://pages--adobe.hlx.page/stock/

also gives an error. I don't know how this will be deployed exactly so I could hardcode a URL but I wouldn't know what it is.

For now I used a variant of the code that takes us to /stock/en/ (or whatever language would be in use, again calculated, see code)

Also, I have comments in there I can remove or leave, I put them in because it might seem surprising for me if I came across this, I can easily remove these if you like


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
