### PR TITLE
File location fix for twp template

### DIFF
--- a/templates/tl/tl.js
+++ b/templates/tl/tl.js
@@ -139,7 +139,7 @@ async function decorateStep() {
     }
     document.title=currentStep.Title;
     if (currentStep['Practice File']) {
-        document.querySelector('main .content>p>a').setAttribute('href', currentStep['Practice File']);
+        document.querySelector('main .content>p>a').setAttribute('href', `/static/twp3/practice-files/${currentStep['Practice File']}`);
     }
 
     if (currentStep.Video.startsWith('https://images-tv.adobe.com')) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Location of download file was not pointing in the right location inside the href=""

Current -> pages.adobe.com/photoshop/en/twp3/design/file-name.zip

new -> pages.adobe.com/static/twp3/practice-files/file-name.zip


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
