### PR TITLE
Headline color fix for tl-masterclass single page

### DIFF
--- a/templates/default/checklist.js
+++ b/templates/default/checklist.js
@@ -146,7 +146,7 @@ function setTranscript(index) {
   transcripts.forEach(function(el) {
     el.style.display = 'none'
   })
-  transcripts[index - 1].style.display = 'block'
+  transcripts[index - 2].style.display = 'block'
 }
 
 function addState(evt) {

--- a/templates/tl-masterclass/tl-masterclass.css
+++ b/templates/tl-masterclass/tl-masterclass.css
@@ -12,6 +12,11 @@
   .tl-masterclass .appear .default:first-of-type h1 {
     color: black;
   }
+
+  .premiere.step main .default:first-of-type h1 {
+    color: white !important;
+  }
+
   
   main .card {
     width: 315px;


### PR DESCRIPTION
Fixed step page headline color on Premiere Pro tl-masterclass single page

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
