### PR TITLE
Updates to Learn and Tutorial template for LrC pages

### DIFF
--- a/templates/learn/learn.css
+++ b/templates/learn/learn.css
@@ -81,6 +81,8 @@ body.home .section-wrapper:last-child .default > h2 {
 	margin: 0 0 20px 0;
 }
 
+.default > p > a:only-child, 
+.section-wrapper > p > a:only-child,
 a.button.action,
 body.home .section-wrapper > p > a:only-child {
 	display: inline-block;
@@ -95,12 +97,16 @@ body.home .section-wrapper > p > a:only-child {
 	text-decoration: none;
 	margin-top: 20px;
 	font-size: 16px;
+	-webkit-appearance: none;
 }
 
+.default > p > a:only-child:hover, 
+.section-wrapper > p > a:only-child:hover,
 a.button.action:hover,
 body.home .section-wrapper > p > a:only-child:hover {
 	background: #0D66D0;
 }
+
 
 main a.button {
 	border-width: 2px;
@@ -117,7 +123,9 @@ main a.button {
     color: rgb(110, 110, 110);
     padding-top: 6.5px;
     font-size: 16px;
+	-webkit-appearance: none;
 }
+
 
 main a.button:hover {
     background-color: rgb(110, 110, 110);
@@ -195,7 +203,7 @@ main .card > div:last-child {
 
 main .card h3 {
   	font-size: 20px;
-  	line-height: 25px;
+  	line-height: 27px;
   	margin: 0 0 10px 0;
 }
 
@@ -341,13 +349,13 @@ body.step.loaded {
 	float: left;
 }
 
-.content footer nav a.button:last-child {
-	margin: 0;
-	float: right;
-}
-
 .content .text p {
 	font-family: "Adobe Clean Serif", adobe-clean-serif, sans-serif;
+}
+
+/* hide lrc launch button on non-desktop devices */
+.content footer nav a.button:last-child {
+	display: none;
 }
 
 
@@ -369,6 +377,11 @@ body.step.loaded {
 	main h2 {
 		font-size: 36px;
 		line-height: 45px;
+	}
+	
+	main .default > h2:first-child,
+	main .default .cards + p {
+		text-align: center;
 	}
 	
 	main .default > p {
@@ -399,8 +412,6 @@ body.step.loaded {
 	main .card {
 		max-width: 338px;
 		margin: 0 8px 16px 8px;
-		font-size: 22px;
-		line-height: 28px;
 	}
 	
 	main .card.index-steps {
@@ -418,11 +429,6 @@ body.step.loaded {
 	main .card.index-steps .text {
 		width: 66%;
 	}
-
-	main .card h3 {
-  		font-size: 26px;
-  		line-height: 32px;
-  	}
   	
   	main .default > p:last-child {
 	  	margin-bottom: 0;
@@ -470,6 +476,12 @@ body.step.loaded {
   	.content footer nav {
 		border-top: 1px solid #e1e1e1;
 	    padding-top: 30px;
+	}
+	
+	.content footer nav a.button:last-child {
+		display: inline-block;
+		margin: 0;
+		float: right;
 	}
 
 }

--- a/templates/tutorials/tutorials.css
+++ b/templates/tutorials/tutorials.css
@@ -89,6 +89,7 @@ main .default > p {
 	border: none;
 	padding: 0 20px;
 	text-decoration: none;
+	-webkit-appearance: none;
 }
 
 #beta-form input[type=submit]:hover,
@@ -182,11 +183,20 @@ main .card div:last-child {
 	padding: 40px;
 }
 
-main .card h3 {
+main .card h3,
+main .card h3 a {
   	font-size: 20px;
-  	line-height: 25px;
+  	line-height: 27px;
   	margin: 0 0 10px 0;
   	color: #2C2C2C;
+}
+
+main .card a {
+	display: block; 
+}
+
+main .card:hover h3 a {
+	text-decoration: none;
 }
 
 
@@ -214,7 +224,7 @@ main .card h3 {
 	
 	main .default > p {
 		font-size: 20px;
-		line-height: 25px;
+		line-height: 27px;
 	}
 	
 	main .cards {
@@ -231,7 +241,7 @@ main .card h3 {
 	
 	main .card {
 		width: 338px;
-		margin: 0 8px;
+		margin: 24px 8px 40px 8px;
 		font-size: 22px;
 		line-height: 28px;
 	}
@@ -247,6 +257,11 @@ main .card h3 {
   	
   	header p:first-of-type {
 	  	margin-left: 12px;
+  	}
+  	
+  	main .card-section h2,
+  	main .card-section > p {
+	  	text-align: center;
   	}
 }
 

--- a/templates/tutorials/tutorials.js
+++ b/templates/tutorials/tutorials.js
@@ -14,10 +14,13 @@
         if (cols.length==1 && $rows.length==1) {
             $div=createTag('div', {class:`${cols[0]}`});
             $div.innerHTML=$rows[0].querySelector('td').innerHTML;
+            $table.parentNode.replaceChild($div, $table);
+
         } else {
-            $div=turnTableSectionIntoCards($table, cols) 
+            $div=turnTableSectionIntoCards($table, cols)
+            $table.parentNode.replaceChild($div, $table);
+            $div.parentNode.classList.add('card-section');
         }
-        $table.parentNode.replaceChild($div, $table);
     });
   }
 


### PR DESCRIPTION
CSS and JS updates to Tutorial template for HSL and LrC + Ps page. Added a wee bit of markup + styling for new card section at the bottom. Fixed line height on paragraphs/cards to be 27px instead of 25px.

CSS updates to Tutorial template for CCP version of Color Grading tutorial, adding revised card section styling and fixing mobile bugs.