### PR TITLE
copy alignment fix

### DIFF
--- a/pages/blocks/callout/callout.css
+++ b/pages/blocks/callout/callout.css
@@ -22,6 +22,15 @@ main div.block.callout {
 	width: 100%;
 }
 
+.callout.alignleftcopy p {
+	text-align: left;
+}
+
+.callout.alignleftcopy p:last-of-type {
+	text-align: left;
+}
+
+
 .callout > div {
 	background: #ffffff;
 	font-size: 15px;


### PR DESCRIPTION
The call out card has a p:last-of-type  text-align: right; to ensure the cta is positioned to the right of the card. However, when there's not cta we want to ensure copy is still left-aligned left. the new CSS resolves this fix.