### PR TITLE
feat: add form field types for io app builder form

### DIFF
--- a/.tools/content-sync/content-sync.js
+++ b/.tools/content-sync/content-sync.js
@@ -28,7 +28,7 @@ const EXT_MAP = {
   gsheet: 'json',
   gdoc: 'md',
 };
-const ENVS = ['preview', 'publish', 'code'];
+const ENVS = ['preview', 'publish', 'code', 'live'];
 
 /**
  * Get a promise that resolves in some duration

--- a/pages/blocks/nav/nav.js
+++ b/pages/blocks/nav/nav.js
@@ -61,6 +61,10 @@ function getImageName(pAppName) {
     iconName = iconName !== '' ? iconName : window.pages.product;
   }
 
+  if (!iconName) {
+    iconName = 'adobe';
+  }
+
   return `/icons/${iconName.split(' ').join('')}.svg`;
 }
 

--- a/pages/scripts/scripts.js
+++ b/pages/scripts/scripts.js
@@ -794,7 +794,7 @@ export function parseEmbedPath(path) {
  * @param {import('./index').EmbedData} data
  * @returns {Promise<void>}
  */
-async function insertContentEmbed(el, data) {
+export async function insertContentEmbed(el, data) {
   const { path, basename, dirname } = data;
   const r = await fetch(path);
   if (!r.ok) {

--- a/styles/legacy/styles.css
+++ b/styles/legacy/styles.css
@@ -115,7 +115,7 @@ main svg.icon.icon-behance {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 .selected {


### PR DESCRIPTION
- add `info` field type for giving information to the user without an input (used for slides)
- add `include` column for form definition to insert documents into the form (used in this case to insert images in `info` slides)
- add `redirect` field type for making an optional way to redirect off of form on conditions (ie. "selecting X means user doesn't fit criteria, hide submit button and show redirect")
- fallback to Adobe logo if none other defined in `nav` block

see: https://io-form--pages--adobe.hlx3.page/adobeio/en/devappbuilder/trial/