### PR TITLE
fix: suppress redirect on lesser envs

### DIFF
--- a/components/en/countdown/countdown.js
+++ b/components/en/countdown/countdown.js
@@ -38,7 +38,7 @@ export default function decorate($block, name, doc) {
     }
     const url = new URL(link.href);
     const href = url.pathname + url.search;
-    if (window.location.hostname === 'localhost') {
+    if (window.location.hostname !== 'pages.adobe.com') {
       $description.innerHTML = `<a href='${href}'>take me to a landing page</a>`;
     } else {
       window.location.href = href;


### PR DESCRIPTION
the current homepage redirects to selected landing pages, which makes it nearly impossible to publish the page with the sidekick...

compare:
https://less-redirect--pages--adobe.hlx3.page/
https://main--pages--adobe.hlx3.page/