### PR TITLE
fix: load header.plain.html on non-templated pages if no nav block

### DIFF
--- a/pages/scripts/scripts.js
+++ b/pages/scripts/scripts.js
@@ -1037,9 +1037,7 @@ const linkInNewTabHelper = () => {
   const links = document.querySelectorAll('a');
   links.forEach((link) => {
     if (link.innerText.includes('[!]')) {
-      console.log('we here');
       const linkText = link.innerText.split('[!]')[0];
-      console.log(linkText);
       link.innerText = linkText;
       link.setAttribute('target', '_blank');
     }
@@ -1152,12 +1150,21 @@ async function decoratePage() {
 
     if (!template) {
       loadBlocks(mainEl);
+
+      const headerContents = document.querySelectorAll('header > *');
+      if (!blocksIncluded.includes('nav') && headerContents.length === 0) {
+      // try to load from header.plain.html
+        loadLocalHeader().then(() => {
+          const div = document.querySelector('header > div');
+          if (div) {
+            div.classList.add('nav');
+            div.setAttribute('data-block-name', 'nav');
+            loadBlock(div);
+          }
+        });
+      }
     }
 
-    if (!blocksIncluded.includes('nav')) {
-      // try to load from header.plain.html
-      loadLocalHeader();
-    }
     loadCSS('/pages/styles/lazy-styles.css');
   });
 }

--- a/pages/scripts/scripts.js
+++ b/pages/scripts/scripts.js
@@ -69,6 +69,11 @@ const cssIncluded = {};
 const jsIncluded = {};
 
 /**
+ * Array of block names, pending or loaded.
+ */
+const blocksIncluded = [];
+
+/**
  * Emitter handlers
  * @type {Record<string, Function[]>}
  */
@@ -647,6 +652,8 @@ export async function loadBlock($block) {
 
   if (ignoredBlocks.includes(blockName)) return;
 
+  blocksIncluded.push(blockName);
+
   const reqCSS = reqCSSBlocks.includes(blockName);
   lgr.debug('loadBlock', { blockName });
   const { jsProm } = loadModuleDir($block, `/pages/blocks/${blockName}/`, blockName, reqCSS);
@@ -1145,6 +1152,11 @@ async function decoratePage() {
 
     if (!template) {
       loadBlocks(mainEl);
+    }
+
+    if (!blocksIncluded.includes('nav')) {
+      // try to load from header.plain.html
+      loadLocalHeader();
     }
     loadCSS('/pages/styles/lazy-styles.css');
   });


### PR DESCRIPTION
pages using template and header.html: 
https://header-fix--pages--adobe.hlx3.page/photoshop/br/tl/design/step?1
https://header-fix--pages--adobe.hlx3.page/illustrator/en/tl/thr-layout-home/

pages using nav block: 
https://header-fix--pages--adobe.hlx3.page/cc-growth-sandbox/test/blocks
https://header-fix--pages--adobe.hlx3.page/photoshop/en/prerelease-api/

pages with blocks, no template, and header.html (fixed):
https://header-fix--pages--adobe.hlx3.page/character/en/body-tracker