### PR TITLE
fix(advocates-pages): fix additional bugs on hero banners

### DIFF
--- a/templates/stock-advocates/stock-advocates.css
+++ b/templates/stock-advocates/stock-advocates.css
@@ -362,10 +362,13 @@ main .artist-bio-hero-section {
     position: absolute;
     height: 100%;
     width: 100%;
-    object-fit: cover;
     top: 0;
     left: 0;
     z-index: -1;
+  }
+  main .artist-bio-hero-section .image img {
+    object-fit: cover;
+    object-position: 65%;
   }
 }
 
@@ -490,9 +493,11 @@ body.artist-development-fund main h1
 
 body.artist-development-fund .hero-section {
   height: 60vh;
+  min-height: 475px;
 }
 body.artist-development-fund .hero-section+div {
   height: 40vh;
+  min-height: 440px;;
 }
 
 body.artist-development-fund h3 a:any-link {
@@ -1365,7 +1370,9 @@ body.artist-bio .columns .text h5 {
     
   main>div.section-wrapper .hero-carousel {
     position: relative;
-    padding-top: 65vh;
+    padding-top: 100%;
+    height: 65vh;
+    min-height: 475px;
     perspective: 100px;
     width: 100%;
   }
@@ -1392,6 +1399,7 @@ body.artist-bio .columns .text h5 {
       line-height: 1em;
       pointer-events: none;
       height: 65vh;
+      min-height: 475px;
   }
 
   @media (min-width:1000px) {


### PR DESCRIPTION
Fix additional bugs on hero banners due to vh value not having a min-height, for example:
https://advocates-pages--pages--webistry-development.hlx3.page/stock/en/advocates/
before:
![image](https://user-images.githubusercontent.com/62023521/145072194-3aa0ada0-8597-44d9-8f89-4524c19431d1.png)
after:
![image](https://user-images.githubusercontent.com/62023521/145072835-aea03f1a-c47e-4b87-84b7-5b98be04a5fc.png)

https://advocates-pages--pages--webistry-development.hlx3.page/stock/en/advocates/artist-development-fund
before:
![image](https://user-images.githubusercontent.com/62023521/145072227-7f8f17bb-f3aa-4302-b5d9-3e0773a5f47b.png)
after: 
![image](https://user-images.githubusercontent.com/62023521/145072461-ecae8678-6e94-4e46-b326-69f9dcc89edd.png)

Also fixed the positioning of artist in artist feature page: 
https://advocates-pages--pages--webistry-development.hlx3.page/stock/en/advocates/artists/adam-perez
before:
![image](https://user-images.githubusercontent.com/62023521/145072131-3c7a77c0-0a59-48f9-b0ca-638d747a00a5.png)
after:
![image](https://user-images.githubusercontent.com/62023521/145072037-e461df46-b3f0-4c76-bd26-ca72f1f9c7c9.png)

