### PR TITLE
fix(advocates-artists): Bug fixes: mobile menu not closing properly on anchor click & fix artist pages some pictures being hidden

### DIFF
--- a/templates/stock-advocates/stock-advocates.css
+++ b/templates/stock-advocates/stock-advocates.css
@@ -350,10 +350,10 @@ main .artist-bio-hero-section {
 
 @media (max-width: 1030px) {
   main .artist-bio-hero-section .text {
-    position: unset;
+    position: relative;
     height: 100%;
     display: block;
-    padding: 5rem 3rem;
+    padding: 2rem 2rem 1rem 2rem;
     width: 100%;
     z-index: 2;
     text-align: left;
@@ -364,7 +364,7 @@ main .artist-bio-hero-section {
     width: 100%;
     top: 0;
     left: 0;
-    z-index: -1;
+    z-index: 0;
   }
   main .artist-bio-hero-section .image img {
     object-fit: cover;

--- a/templates/stock-advocates/stock-advocates.js
+++ b/templates/stock-advocates/stock-advocates.js
@@ -469,6 +469,15 @@ async function decorateHeader() {
       document.body.classList.remove('noscroll');
     }
   });
+
+  const $links = Array.from($menu.querySelectorAll('a'));
+  $links.forEach(($a) => {
+    $a.addEventListener('click', () => {
+      $header.classList.remove('expanded');
+      document.body.classList.remove('noscroll');
+    });
+  });
+  
   decorateLogo();
 }
 


### PR DESCRIPTION
- Fixed the mobile menu not closing properly when clicking an anchor link, preventing scroll

- Fixed some artists pictures being hidden on mobile, for example:

https://pages.adobe.com/stock/en/advocates/artists/amaal-said
before:
![image](https://user-images.githubusercontent.com/62023521/145085307-28935db2-0881-4dd1-b747-abaf236cd04a.png)
after:
![image](https://user-images.githubusercontent.com/62023521/145085232-cdeca42a-b120-4183-94a7-7ff73e4d6a4e.png)

https://pages.adobe.com/stock/en/advocates/artists/sophie-alp
before: 
![image](https://user-images.githubusercontent.com/62023521/145085353-ceba3a3a-629e-41e1-ba48-99b700da578f.png)
after:
![image](https://user-images.githubusercontent.com/62023521/145085554-9d08b7af-882c-4ab6-a4ba-ce7d3693ceac.png)

Some pictures were working but not others... this will pull request fix it
![image](https://user-images.githubusercontent.com/62023521/145085609-ebe071a1-5650-4943-a8ee-81036eb99daa.png)
