### PR TITLE
Added current year to footer copyright.

### DIFF
--- a/pages/scripts/scripts.js
+++ b/pages/scripts/scripts.js
@@ -912,12 +912,13 @@ export async function loadTemplate(template) {
  * @param {string} locale
  */
 export function getLocalizedFooter(locale) {
+  const currentYear = new Date().getFullYear();
   const template = ({
     links,
     cookies,
   }) => `
   <div>
-    <p>Copyright © 2021 Adobe. All rights reserved.</p>
+    <p>Copyright © ${currentYear} Adobe. All rights reserved.</p>
     <ul>
       ${links}
     </ul>


### PR DESCRIPTION
Added an updated year to the footer and removed the hard coded year value with `new Date()` method.

example, footer on this page.
- https://footer--pages--adobe.hlx3.page/illustrator/en/tl/thr-layout-home/
