### PR TITLE
fix(consonant-blocks): fix links opening in new tab as requested

### DIFF
--- a/templates/consonant/consonant.js
+++ b/templates/consonant/consonant.js
@@ -726,6 +726,11 @@ export function externalLinks(selector) {
     if (linkValue.includes('//') && !linkValue.includes('pages.adobe')) {
       linkItem.setAttribute('target', '_blank');
     }
+    if (window.pages.product && !linkValue.includes(window.pages.product)) {
+      linkItem.setAttribute('target', '_blank');
+    } else if (window.pages.project && !linkValue.includes(window.pages.project)) {
+      linkItem.setAttribute('target', '_blank');
+    }
   });
 }
 

--- a/templates/consonant/consonant.js
+++ b/templates/consonant/consonant.js
@@ -725,8 +725,7 @@ export function externalLinks(selector) {
 
     if (linkValue.includes('//') && !linkValue.includes('pages.adobe')) {
       linkItem.setAttribute('target', '_blank');
-    }
-    if (window.pages.product && !linkValue.includes(window.pages.product)) {
+    } else if (window.pages.product && !linkValue.includes(window.pages.product)) {
       linkItem.setAttribute('target', '_blank');
     } else if (window.pages.project && !linkValue.includes(window.pages.project)) {
       linkItem.setAttribute('target', '_blank');


### PR DESCRIPTION
Fixed links to open to new tab if the url is external.

Automatically fixes the following links behaviors (as requested):

URL for testing:

- https://fix-links-new-tab--pages--Webistry-Development.hlx3.page/stock/en/artisthub/drafts/artisthub-2.2/


The menu items in this example should be the following: 

Home -> `/stock/en/artisthub/drafts/artisthub-2.2/`
Requested Behavior: Does not open in new tab

Get Started -> `/stock/en/artisthub/drafts/artisthub-2.2/get-started`
Requested Behavior: Does not open in new tab

Learn -> `/stock/en/artisthub/drafts/artisthub-2.2/learn`
Requested Behavior: Does not open in new tab

Learn/Research Insights -> `/stock/en/artisthub/drafts/artisthub-2.2/learn/research-insights`
Requested Behavior: Does not open in new tab

Get Inspired -> `/stock/en/artisthub/drafts/artisthub-2.2/get-inspired`
Requested Behavior: Does not open in new tab

Advocates Program -> `/stock/en/advocates/`
Requested Behavior: Opens in a new tab
(because the project is advocates instead of artisthub)

Community -> `/stock/en/artisthub/drafts/artisthub-2.2/community`
Requested Behavior: Does not open in new tab

Community/Stock Mentors ->  -> `/stock/en/artisthub/drafts/artisthub-2.2/community/stock-mentors`
Requested Behavior: Does not open in new tab

Community/Apply for funding -> `/stock/en/advocates/artist-development-fund`
Requested Behavior: Opens in a new tab
(because the project is advocates instead of artisthub)

Community/Join the Community -> `https://discord.gg/adobestock`
Requested Behavior: Opens in a new tab
(because it is an external link)

Portal -> `https://contributor.stock.adobe.com/`
Requested Behavior: Opens in a new tab
(because it is an external link)


After testing, it looks like the links are working as intended!
