### PR TITLE
added heavier font weight for h1s that container strong text

### DIFF
--- a/pages/blocks/textoverbackground/textoverbackground.css
+++ b/pages/blocks/textoverbackground/textoverbackground.css
@@ -34,6 +34,10 @@ main div.block.textoverbackground {
   color: #ffffff !important;
 }
 
+.textoverbackground h1 strong {
+  font-weight:  bolder;
+}
+
 .textoverbackground.ondark p {
   color: #ffffff !important;
 }


### PR DESCRIPTION
Any element that gets a `<strong>` element like:
`<h1><strong>Titlte</strong></h1>`

will get a heavier font size. 

exmaple:
https://text-over-background--pages--adobe.hlx3.page/express/en/learn/thank-you