### PR TITLE
Artist Hub sharing block

### DIFF
--- a/templates/consonant/blocks/share/share.js
+++ b/templates/consonant/blocks/share/share.js
@@ -11,26 +11,48 @@
  */
 import {
   isNodeName,
+  createTag,
 } from '../../consonant.js';
 
 // eslint-disable-next-line no-unused-vars
 export default function decorate($block) {
   // Decorate social media icon list
   const $inlineSVGicons = Array.from($block.querySelectorAll('svg.icon'));
-  $inlineSVGicons.forEach((icon) => {
-    let $c = icon.parentElement;
+  $inlineSVGicons.forEach(($icon) => {
+    const url = encodeURIComponent(window.location.href);
+    let link = null;
+
+    if ($icon.classList.contains('icon-facebook')) {
+      link = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+    } else if ($icon.classList.contains('icon-linkedin')) {
+      link = `https://www.linkedin.com/sharing/share-offsite/?url=${url}`;
+    } else if ($icon.classList.contains('icon-twitter')) {
+      link = `https://twitter.com/share?&url=${url}`;
+    } else if ($icon.classList.contains('icon-pinterest')) {
+      link = `https://pinterest.com/pin/create/button/?url=${url}`;
+    } else {
+      $icon.remove();
+    }
+
+    let $c = $icon.parentElement;
     if ((isNodeName($c, 'a'))) {
       $c = $c.parentElement;
     }
     if (!isNodeName($c, 'p')) {
       const p = document.createElement('p');
       $c.appendChild(p);
-      p.appendChild(icon);
+      p.appendChild($icon);
       $c = p;
     }
     if ($c.children.length > 1) {
       $c.classList.add('icon-container');
-      icon.setAttribute('fill', 'currentColor');
+      $icon.setAttribute('fill', 'currentColor');
+    }
+
+    if (link) {
+      const $link = createTag('a', { target: '_blank', href: link });
+      $icon.parentNode.replaceChild($link, $icon);
+      $link.append($icon);
     }
   });
 

--- a/templates/consonant/blocks/share/share.js
+++ b/templates/consonant/blocks/share/share.js
@@ -51,6 +51,9 @@ export default function decorate($block) {
 
     if (link) {
       const $link = createTag('a', { target: '_blank', href: link });
+      $link.addEventListener('click', () => {
+        window.open($link.href, 'newwindow', 'width=600, height=400');
+      });
       $icon.parentNode.replaceChild($link, $icon);
       $link.append($icon);
     }

--- a/templates/consonant/consonant.js
+++ b/templates/consonant/consonant.js
@@ -98,6 +98,22 @@ export function getLanguage() {
 }
 
 /**
+ * Creates a tag with the given name and attributes.
+ * @param {string} name The tag name
+ * @param {object} attrs An object containing the attributes
+ * @returns The new tag
+ */
+export function createTag(name, attrs) {
+  const el = document.createElement(name);
+  if (typeof attrs === 'object') {
+    for (const [key, value] of Object.entries(attrs)) {
+      el.setAttribute(key, value);
+    }
+  }
+  return el;
+}
+
+/**
  * Retrieves the content of a metadata tag.
  * @param {string} name The metadata name (or property)
  * @returns {string} The metadata value


### PR DESCRIPTION
### Test URL

https://artisthub_sharing_block--pages--webistry-development.hlx3.page/stock/en/artisthub/drafts/artisthub-example/learn/research-insights/industry-insights-financial-services

### Notes

This is inspired from David's sharing facilities on the blog refactor, example URL can be found here:

https://blog-refactor--express-website--adobe.hlx3.page/drafts/pdooley/blog/introducing-creative-cloud-express

It seems that Facebook's link won't work locally, but when tested with the proper live urls it works as expected, therefore I would consider launching it and monitoring the situation when the pages go live.

Additionally, I've imported the createTag function into consonant.js. If you would rather that i use directly from script.js let me know!