### PR TITLE
feat(consonant): video block added, browser compatibility changes made

### DIFF
--- a/templates/consonant/blocks/images/images.css
+++ b/templates/consonant/blocks/images/images.css
@@ -1,5 +1,5 @@
 main .images {
-    max-width: 1200px;
+    max-width: var(--max-width-block-laptop);
     margin-left: auto;
     margin-right: auto;
     display: inline-block;

--- a/templates/consonant/blocks/images/images.css
+++ b/templates/consonant/blocks/images/images.css
@@ -17,7 +17,10 @@ main .images > div {
 
 main .images > div > div {
     display: flex;
-    gap: 32px;
+}
+
+main .images > div > div > *:not(:last-child) {
+    margin-right: 32px;
 }
 
 main .images picture {
@@ -64,7 +67,7 @@ main .images p.icon-container a {
 }
 
 @media screen and (max-width: 900px) {
-    main .images > div > div {
-        gap: 8px;
+    main .images > div > div > *:not(:last-child) {
+        margin-right: 8px;
     }
 }

--- a/templates/consonant/blocks/list/list.css
+++ b/templates/consonant/blocks/list/list.css
@@ -20,7 +20,10 @@ main .list > div {
     align-items: center;
     border-bottom: 1px solid #707070;
     padding: 17px 0 15px 0;
-    gap: 16px;
+}
+
+main .list > div > *:not(:last-child) {
+    margin-right: 16px;
 }
 
 main .list > div > div:first-child :not(div) {

--- a/templates/consonant/blocks/share/share.css
+++ b/templates/consonant/blocks/share/share.css
@@ -25,12 +25,15 @@ main .share p.icon-container a {
     justify-content: flex-start;
     align-items: center;
     padding-bottom: 0;
-    gap: 15px;
 }
 
 main .share.center p.icon-container,
 main .share.center p.icon-container a {
     justify-content: center;
+}
+
+main .share p.icon-container > *:not(:last-child) {
+    margin-right: 15px;
 }
 
 main .share p.icon-container svg {
@@ -50,8 +53,11 @@ main .share .contributors {
     display: flex;
     border-bottom: 1px solid #707070;
     padding: 16px 0;
-    gap: 16px;
     align-items: center;
+}
+
+main .share .contributors > *:not(:last-child) {
+    margin-right: 16px;
 }
 
 main .share .contributors h1,

--- a/templates/consonant/blocks/sitemap/sitemap.css
+++ b/templates/consonant/blocks/sitemap/sitemap.css
@@ -34,7 +34,6 @@ main .sitemap-container .sitemap {
 main .sitemap-container .sitemap p > ul {
     display: flex;
     flex-wrap: wrap;
-    gap: 40px;
 }
 
 main .sitemap-container .sitemap p > ul > li {
@@ -42,6 +41,11 @@ main .sitemap-container .sitemap p > ul > li {
     padding-bottom: 30px;
     flex: 1 1 0px;
     min-width: 160px;
+    margin-right: 40px;
+}
+
+main .sitemap-container .sitemap p > ul > li:last-child {
+    margin-right: 0;
 }
 
 main .sitemap-container .sitemap p > ul li {
@@ -81,6 +85,9 @@ main .sitemap-container .sitemap p > ul > li > a:hover {
 }
 
 @media screen and (max-width: 1240px) {
+    main .sitemap-container .sitemap p > ul {
+        gap: 40px;
+    }
     
     main .sitemap-container .sitemap {
         max-width: 800px;
@@ -88,14 +95,15 @@ main .sitemap-container .sitemap p > ul > li > a:hover {
     }
 
     main .sitemap-container .sitemap p > ul > li {
-        min-width: 240px;
-        max-width: 25%;
+        min-width: 200px;
+        max-width: 20%;
     }
 }
 
 @media screen and (max-width: 920px) {
     main .sitemap-container .sitemap p > ul > li {
         min-width: 27%;
+        margin: 0;
     }
     
     main .sitemap-container .sitemap {

--- a/templates/consonant/blocks/tags/tags.css
+++ b/templates/consonant/blocks/tags/tags.css
@@ -11,8 +11,8 @@ main .section-wrapper .block.tags {
 
 main .tags > div > div {
     display: flex;
+    justify-content: flex-start;
     flex-wrap: wrap;
-    gap: 16px;
 }
 
 main .tags > div p:not(:empty),
@@ -24,6 +24,9 @@ main .tags > div a:not(:empty) {
     border: 1px solid #959595;
     border-radius: 4px;
     cursor: default;
+    white-space: nowrap;
+    margin-right: 16px;
+    margin-bottom: 8px;
 }
 
 main .share + .tags {

--- a/templates/consonant/blocks/video/video.css
+++ b/templates/consonant/blocks/video/video.css
@@ -22,6 +22,7 @@ main .video div {
   margin: 0;
 }
 
+main .video.full-width,
 main .video.full-width {
   padding: 0;
   max-width: unset;

--- a/templates/consonant/blocks/video/video.css
+++ b/templates/consonant/blocks/video/video.css
@@ -23,7 +23,7 @@ main .video div {
 }
 
 main .video.full-width,
-main .video.full-width {
+main .video.fullwidth {
   padding: 0;
   max-width: unset;
 } 

--- a/templates/consonant/blocks/video/video.css
+++ b/templates/consonant/blocks/video/video.css
@@ -1,0 +1,28 @@
+main .video {
+  max-width: calc(var(--max-width-block-laptop) + (var(--gutter) * 2));
+  margin-left: auto;
+  margin-right: auto;
+  display: inline-block;
+  width: 100%;
+  padding: 0 var(--gutter);
+  box-sizing: border-box;
+}
+
+main .video-container > div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: unset;
+  padding: 0;
+}
+
+main .video div {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+main .video.full-width {
+  padding: 0;
+  max-width: unset;
+} 

--- a/templates/consonant/blocks/video/video.js
+++ b/templates/consonant/blocks/video/video.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  createTag,
+} from '../../consonant.js';
+
+export default function decorate($block) {
+  let autoplay = '';
+  let loop = '';
+
+  if ($block.classList.contains('full') && $block.classList.contains('width')) {
+    $block.classList.remove('full', 'width');
+    $block.classList.add('full-width');
+  }
+
+  const $a = $block.querySelector('a');
+
+  if ($a.textContent.startsWith('https://')) {
+    const url = new URL($a.href);
+    const usp = new URLSearchParams(url.search);
+    let embedHTML = '';
+    let type = '';
+
+    if ($a.href.startsWith('https://www.youtube.com/watch') || $a.href.startsWith('https://youtu.be/')) {
+      let vid = usp.get('v');
+      if (url.host === 'youtu.be') vid = url.pathname.substr(1);
+
+      if ($block.classList.contains('autoplay')) {
+        autoplay = '&amp;autoplay=1&amp;mute=1';
+        loop = `&amp;loop=1&amp;playlist=${vid}`;
+      }
+
+      type = 'youtube';
+      embedHTML = /* html */`
+        <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+          <iframe src="https://www.youtube.com/embed/${vid}?rel=0&amp;modestbranding=1&amp;playsinline=1&amp;autohide=1&amp;showinfo=0&amp;controls=1&amp;rel=0${autoplay}${loop}" frameBorder="0" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no" allow="encrypted-media; accelerometer; gyroscope; picture-in-picture; autoplay" title="content from youtube" loading="lazy"></iframe>
+        </div>
+        `;
+    } else if ($a.href.includes('tv.adobe.com')) {
+      const $video = createTag('iframe', { src: $a.href, class: 'embed tv-adobe' });
+
+      $a.parentElement.replaceChild($video, $a);
+    }
+
+    if (type) {
+      const $embed = createTag('div', { class: `embed embed-oembed embed-${type}` });
+      const $div = $a.closest('div');
+      $embed.innerHTML = embedHTML;
+      $div.parentElement.replaceChild($embed, $div);
+    }
+  }
+}

--- a/templates/consonant/consonant.css
+++ b/templates/consonant/consonant.css
@@ -362,8 +362,11 @@ p.button-container {
   display: flex;
   margin: 10px 0;
   flex-wrap: wrap;
-  gap: 14px;
   justify-content: flex-start;
+}
+
+p.button-container > *:not(:last-child) {
+  margin-right: 14px;
 }
 
 .center p.button-container,

--- a/templates/consonant/consonant.js
+++ b/templates/consonant/consonant.js
@@ -259,7 +259,7 @@ export function decorateBlocks($main) {
     });
 
     // Allow for variants...
-    const blocksWithVariants = ['columns', 'cards', 'marquee', 'separator', 'quote', 'images', 'share'];
+    const blocksWithVariants = ['columns', 'cards', 'marquee', 'separator', 'quote', 'images', 'share', 'video'];
     blocksWithVariants.forEach((b) => {
       if (blockName.startsWith(`${b}-`)) {
         const options = blockName.substring(b.length + 1).split('-').filter((opt) => !!opt);

--- a/templates/stock-advocates/stock-advocates.js
+++ b/templates/stock-advocates/stock-advocates.js
@@ -223,20 +223,17 @@ export function decorateBlocks(
 
 function decorateVideo() {
   let autoplay = '';
+  let loop = '';
 
-  document.querySelectorAll('main .video-container').forEach(($container) => {
+  document.querySelectorAll('main .video.block').forEach(($block) => {
+    const $a = $block.querySelector('a');
+
+    const $container = $block.closest('.section-wrapper');
+
     if ($container.classList.contains('full') && $container.classList.contains('width')) {
       $container.classList.remove('full', 'width');
       $container.classList.add('full-width');
     }
-
-    if ($container.classList.contains('autoplay')) {
-      autoplay = `&amp;autoplay=1&amp;mute=1`;
-    }
-  });
-
-  document.querySelectorAll('main .video.block').forEach(($block) => {
-    const $a = $block.querySelector('a');
 
     if ($a.textContent.startsWith('https://')) {
       const url = new URL($a.href);
@@ -248,10 +245,15 @@ function decorateVideo() {
         let vid = usp.get('v');
         if (url.host === 'youtu.be') vid = url.pathname.substr(1);
 
+        if ($container.classList.contains('autoplay')) {
+          autoplay = '&amp;autoplay=1&amp;mute=1';
+          loop = `&amp;loop=1&amp;playlist=${vid}`;
+        }
+
         type = 'youtube';
         embedHTML = /* html */`
           <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
-            <iframe src="https://www.youtube.com/embed/${vid}?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0&amp;controls=1${autoplay}" frameBorder="0" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no" allow="encrypted-media; accelerometer; gyroscope; picture-in-picture; autoplay" title="content from youtube" loading="lazy"></iframe>
+            <iframe src="https://www.youtube.com/embed/${vid}?rel=0&amp;modestbranding=1&amp;playsinline=1&amp;autohide=1&amp;showinfo=0&amp;controls=1&amp;rel=0${autoplay}${loop}" frameBorder="0" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no" allow="encrypted-media; accelerometer; gyroscope; picture-in-picture; autoplay" title="content from youtube" loading="lazy"></iframe>
           </div>
           `;
       } else if ($a.href.includes('tv.adobe.com')) {


### PR DESCRIPTION
- Browser compatibility issues with `gap` CSS attribute fixed for Safari
- Video block added for consonant blocks, to use in the artisthub pages

Test URLs: 
- https://artist-hub--pages--webistry-development.hlx3.page/stock/en/artisthub/get-inspired/creative-trends/be-bold-visual-trend-powerfully-playful
- https://artist-hub--pages--webistry-development.hlx3.page/stock/en/artisthub/drafts/block-test
- https://artist-hub--pages--webistry-development.hlx3.page/stock/en/artisthub/drafts/block-library

variants: 
- full-width - changes the size of the video to full width
- autplay - mutes and autoplays the video, and also loops the video