### PR TITLE
appending instead overriding to avoid error.

### DIFF
--- a/pages/blocks/checklist/checklist.js
+++ b/pages/blocks/checklist/checklist.js
@@ -100,7 +100,7 @@ function layoutSetUp() {
     </div>
   `;
   videoEl.innerHTML = video;
-  document.querySelector('.clvideo > div > div:last-of-type').innerHTML = transcript.outerHTML;
+  document.querySelector('.clvideo').append(transcript);
   document.querySelector('.transcript-container').remove();
 
   function runVideo() {


### PR DESCRIPTION
There was a bug on checklist.js that trying overriding last contents with transcript without checking what's in there. For this error case, the transcripts  contents override the video contents  so the video is gone and cause other js error that assumes the video always exists..

With this fix, it will append transcripts element instead write into the last `div`.

Current URL (w/ error)
https://main--pages--adobe.hlx.page/creativecloud/pt/photography-plan/lightroom/presets

Fixed:
https://checklist-fix--pages--adobe.hlx.page/creativecloud/pt/photography-plan/lightroom/presets