### PR TITLE
fix(consonant): video in cards block + style fixes for empty-text marquee block.

### DIFF
--- a/templates/consonant/blocks/cards/cards.css
+++ b/templates/consonant/blocks/cards/cards.css
@@ -391,6 +391,12 @@ main .cards.horizontal .card {
     main .section-wrapper > div > .cards + p.button-container {
         justify-content: center;
     }
+    
+    main .cards.col-1-cards .card-banner .icon,
+    main .cards.col-2-cards .card-banner .icon,
+    main .cards.col-3-cards .card-banner .icon {
+        top: 132px;
+    }
 }
 
 @media screen and (max-width: 1200px) {

--- a/templates/consonant/blocks/cards/cards.css
+++ b/templates/consonant/blocks/cards/cards.css
@@ -56,10 +56,6 @@ main .cards .card {
     position: relative;
 }
 
-main .cards.col-2-cards .card {
-    max-width: unset;
-}
-
 main .cards .card-text {
     padding: 16px;
     padding-bottom: 20px;
@@ -202,27 +198,42 @@ main .cards.overlay .card-banner .icon {
     bottom: 28px;
 }
 
-main .cards .card-picture img {
+main .cards .card-picture img,
+main .cards .card-picture video {
     width: 100%;
     height: 200px;
     object-fit: cover;
     display: block;
 }
 
-main .cards.col-5-cards .card-picture img {
+
+main .cards .card-picture video {
+    min-width: 101%;
+    transform: translateX(-0.5%);
+}
+
+main .cards.col-5-cards .card-picture img,
+main .cards.col-5-cards .card-picture video {
     height: 150px;
 }
 
 main .cards.col-1-cards .card-picture img,
 main .cards.col-2-cards .card-picture img,
-main .cards.col-3-cards .card-picture img {
+main .cards.col-3-cards .card-picture img,
+main .cards.col-1-cards .card-picture video,
+main .cards.col-2-cards .card-picture video,
+main .cards.col-3-cards .card-picture video {
     height: 300px;
 }
 
 main .cards.overlay.cards.col-1-cards .card-picture img,
 main .cards.overlay.cards.col-2-cards .card-picture img,
 main .cards.overlay.cards.col-3-cards .card-picture img,
-main .cards.overlay .card-picture img {
+main .cards.overlay .card-picture img,
+main .cards.overlay.cards.col-1-cards .card-picture video,
+main .cards.overlay.cards.col-2-cards .card-picture video,
+main .cards.overlay.cards.col-3-cards .card-picture video,
+main .cards.overlay .card-picture video {
     height: 100%;
 }
 
@@ -327,11 +338,16 @@ main .cards.horizontal .card-picture {
 main .cards.horizontal.cards.col-1-cards .card-picture img,
 main .cards.horizontal.cards.col-2-cards .card-picture img,
 main .cards.horizontal.cards.col-3-cards .card-picture img,
-main .cards.horizontal .card-picture img {
+main .cards.horizontal .card-picture img,
+main .cards.horizontal.cards.col-1-cards .card-picture video,
+main .cards.horizontal.cards.col-2-cards .card-picture video,
+main .cards.horizontal.cards.col-3-cards .card-picture video,
+main .cards.horizontal .card-picture video {
     height: 100%;
 }
 
-main .cards.horizontal .card-picture img {
+main .cards.horizontal .card-picture img,
+main .cards.horizontal .card-picture video {
     position: absolute;
     top: 0;
     left: 0;
@@ -357,7 +373,10 @@ main .cards.horizontal .card {
 
     main .cards.col-1-cards .card-picture img,
     main .cards.col-2-cards .card-picture img,
-    main .cards.col-3-cards .card-picture img {
+    main .cards.col-3-cards .card-picture img,
+    main .cards.col-1-cards .card-picture video,
+    main .cards.col-2-cards .card-picture video,
+    main .cards.col-3-cards .card-picture video {
         height: 200px;
     }
 
@@ -427,6 +446,10 @@ main .cards.horizontal .card {
         flex-wrap: wrap;
         max-width: var(--max-width-mobile);
     }
+
+    main .cards .card {
+        max-width: 500px;
+    }
 }
 
 main .cards + p,
@@ -435,7 +458,8 @@ main .cards + a {
     padding-top: 0;
 }
 
-main .cards.nocrop:not(.horizontal):not(.overlay) .card-picture img {
+main .cards.nocrop:not(.horizontal):not(.overlay) .card-picture img,
+main .cards.nocrop:not(.horizontal):not(.overlay) .card-picture video {
     height: auto;
     object-fit: contain;
 }
@@ -446,12 +470,15 @@ main .cards:not(.horizontal) .card-container-link .card-picture {
     overflow: hidden;
 }
 
-main .cards:not(.horizontal) .card-container-link .card-picture img {
+main .cards:not(.horizontal) .card-container-link .card-picture img,
+main .cards:not(.horizontal) .card-container-link .card-picture video {
     transition: filter 0.3s, transform 0.3s;
 }
 
 main .cards:not(.horizontal) .card-container-link:hover .card-picture img,
-main .cards:not(.horizontal) .card-container-link:focus .card-picture img {
+main .cards:not(.horizontal) .card-container-link:focus .card-picture img,
+main .cards:not(.horizontal) .card-container-link:hover .card-picture video,
+main .cards:not(.horizontal) .card-container-link:focus .card-picture video {
     filter: brightness(1.1);
     transform: scale(1.05);
 }

--- a/templates/consonant/blocks/cards/cards.js
+++ b/templates/consonant/blocks/cards/cards.js
@@ -9,6 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import {
+  transformLinkToAnimation,
+} from '../../consonant.js';
 
 export default function decorate($block) {
   const $cards = Array.from($block.children);
@@ -19,8 +22,8 @@ export default function decorate($block) {
   if (numberOfCards > 0) {
     $block.classList.add(`col-${numberOfCards}-cards`);
   }
-  const $pics = $block.querySelectorAll(':scope picture');
-  $block.querySelectorAll(':scope p:empty').forEach(($p) => $p.remove());
+  const $pics = $block.querySelectorAll('picture');
+  $block.querySelectorAll('p:empty').forEach(($p) => $p.remove());
   if ($pics.length === 1 && $pics[0].parentElement.tagName === 'P') {
     const $parentDiv = $pics[0].closest('div');
     const $parentParagraph = $pics[0].parentNode;
@@ -34,30 +37,41 @@ export default function decorate($block) {
     $card.classList.add('card');
     const $cells = Array.from($card.children);
     let hasLink = false;
-    $cells.forEach(($e, cell) => {
-      const $cardLink = $e.querySelector(':scope a:first-child:last-child');
-      if (cell === 0) {
-        const pic = $e.querySelector(':scope picture');
+    $cells.forEach(($cell, index) => {
+      if (index === 0) {
+        const pic = $cell.querySelector('picture');
         if (pic) {
-          $e.classList.add('card-picture');
+          $cell.classList.add('card-picture');
         } else {
-          $e.classList.add('card-text');
+          const $a = $cell.querySelector('a');
+          if ($a && $a.href.startsWith('https://') && $a.href.endsWith('.mp4')) {
+            let video = null;
+            video = transformLinkToAnimation($a);
+            $cell.innerHTML = '';
+            if (video) {
+              $cell.appendChild(video);
+              $cell.classList.add('card-picture');
+            }
+          } else {
+            $cell.classList.add('card-text');
+          }
         }
-      } else if (cell === 1) {
-        $e.classList.add('card-text');
-      } else if (cell === 2) {
+      } else if (index === 1) {
+        $cell.classList.add('card-text');
+      } else if (index === 2) {
+        const $cardLink = $cell.querySelector('a');
         if ($cardLink) {
-          $e.classList.add('card-link');
+          $cell.classList.add('card-link');
           hasLink = true;
         }
-      } else if (cell === 3) {
-        $e.classList.add('card-banner');
+      } else if (index === 3) {
+        $cell.classList.add('card-banner');
       } else {
-        $e.remove();
+        $cell.remove();
       }
     });
     if (hasLink) {
-      const $cardLink = $card.querySelector(':scope .card-link a');
+      const $cardLink = $card.querySelector('.card-link a');
       if ($cardLink) {
         $cardLink.classList.remove('button');
         $cardLink.classList.add('card-container-link');
@@ -66,7 +80,7 @@ export default function decorate($block) {
         $cells.forEach((div) => {
           $cardLink.append(div);
         });
-        $card.querySelector(':scope .card-link').remove();
+        $card.querySelector('.card-link').remove();
       }
     }
     if (overlay) {

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -531,7 +531,23 @@ main .marquee.center .marquee-column:not(.marquee-image) {
 
     /* no text content */
 
-    main .marquee.empty-content {
+    main .marquee.empty-content,
+    main .marquee.empty-content .background img,
+    main .marquee.empty-content .background video {
         min-height: unset;
+        max-height: var(--marquee-height-md);
+    }
+
+    
+    main .marquee.small.empty-content,
+    main .marquee.small.empty-content .background img,
+    main .marquee.small.empty-content .background video {
+        max-height: var(--marquee-height-sm);
+    }
+
+    main .marquee.large.empty-content,
+    main .marquee.large.empty-content .background img,
+    main .marquee.large.empty-content .background video {
+        max-height: var(--marquee-height-lg);
     }
 }

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -44,7 +44,7 @@ main .section-wrapper.marquee-container > div {
 /* mobile */
 
 main .marquee {
-    padding: 24px 0;
+    padding: 0;
     --marquee-height-sm: 360px;
     --marquee-height-md: 560px;
     --marquee-height-lg: 700px;
@@ -57,7 +57,6 @@ main .marquee {
     flex-direction: column;
     color: var(--color-white);
 }
-
 
 main .marquee h1,
 main .marquee h2 {
@@ -101,7 +100,11 @@ main .marquee .background video {
 
 main .marquee .background img,
 main .marquee .background video {
-    min-height: 260px;
+    min-height: 180px;
+}
+
+main .marquee > .background:last-child {
+    position: unset;
 }
 
 main .marquee .background p {
@@ -121,10 +124,15 @@ main .marquee.light .background a {
 }
 
 main .marquee .background video {
-    width: 100%;
+    width: 101%;
+    transform: translateX(-0.5%);
     height: auto;
     min-height: 100%;
     object-fit: cover;
+}
+
+main .marquee .background .hero-animation-overlay p:first-child {
+    line-height: 0;
 }
 
 main .marquee .background picture ~ p:not(:empty),
@@ -189,6 +197,8 @@ main .marquee .container {
     display: flex;
     flex-direction: column;
     width: 100%;
+    padding-top: 24px;
+    padding-bottom: 24px;
 }
 
 main .marquee .container > div {
@@ -260,11 +270,9 @@ main .marquee.light .background > div > p:not(:first-child):not(:empty) {
 }
 
 
-
 /* large */
 
 main .marquee.large {
-    padding: 0;
     display: block;
     color: var(--color-black);
 }
@@ -288,8 +296,6 @@ main .marquee.large a.button.transparent:any-link:active {
 }
 
 main .marquee.large .container {
-    padding-top: 24px;
-    padding-bottom: 24px;
     margin: 0 auto;
 }
 
@@ -521,5 +527,11 @@ main .marquee.center .marquee-column:not(.marquee-image) {
 
     main .marquee.small {
         min-height: var(--marquee-height-sm);
+    }
+
+    /* no text content */
+
+    main .marquee.empty-content {
+        min-height: unset;
     }
 }

--- a/templates/consonant/blocks/marquee/marquee.js
+++ b/templates/consonant/blocks/marquee/marquee.js
@@ -57,6 +57,8 @@ export default function decorate($block) {
       const $emptyP = $cell.querySelector(':scope > p:first-child:last-child');
       if ($emptyP && $emptyP.childNodes.length === 0) $emptyP.remove();
     });
+  } else {
+    $block.classList.add('empty-content');
   }
   // Remove white space between section with background and marquee:
   const $previousSection = $sectionWrapper.previousElementSibling;


### PR DESCRIPTION
- Added video to the cards block
- Fix bug where marquee with empty content would hide the background image/video in mobile-tablet view
- Vertically centered the marquee background image/video in desktop view
- Fixed card's play icon position on smaller screen

[before](https://main--pages--adobe.hlx.page/stock/en/artisthub/drafts/block-test) / [after](https://style-fixes--pages--webistry-development.hlx.page/stock/en/artisthub/drafts/block-test)