### PR TITLE
fix(consonant): fix line on the right of video, fix missing selector

### DIFF
--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -519,7 +519,7 @@ main .marquee.center .marquee-column:not(.marquee-image) {
     main .marquee.large .background img,
     main .marquee.large .background video {
         max-height: unset;
-        width: 100%;
+        width: 101%;
         height: 100%;
     }
 
@@ -532,22 +532,28 @@ main .marquee.center .marquee-column:not(.marquee-image) {
     /* no text content */
 
     main .marquee.empty-content,
+    main .marquee.empty-content .background,
     main .marquee.empty-content .background img,
     main .marquee.empty-content .background video {
+        position: unset;
         min-height: unset;
         max-height: var(--marquee-height-md);
     }
 
     
     main .marquee.small.empty-content,
+    main .marquee.small.empty-content .background,
     main .marquee.small.empty-content .background img,
     main .marquee.small.empty-content .background video {
+        position: unset;
         max-height: var(--marquee-height-sm);
     }
 
     main .marquee.large.empty-content,
+    main .marquee.large.empty-content .background,
     main .marquee.large.empty-content .background img,
     main .marquee.large.empty-content .background video {
+        position: unset;
         max-height: var(--marquee-height-lg);
     }
 }


### PR DESCRIPTION
- Fix empty line on the right of video in desktop view
- Fix missing selector in one of the css styles which prevents some marquees to show up in desktop view

[before](https://main--pages--adobe.hlx.page/stock/en/artisthub/get-inspired/creative-trends/visual-trend-in-the-groove-call-for-stock-content) / [after](https://small-fix--pages--webistry-development.hlx.page/stock/en/artisthub/get-inspired/creative-trends/visual-trend-in-the-groove-call-for-stock-content)