### PR TITLE
feature request (columns): if image has no link, add link to first CTA button

### DIFF
--- a/templates/consonant/blocks/columns/columns.css
+++ b/templates/consonant/blocks/columns/columns.css
@@ -188,12 +188,6 @@ main .columns .column-picture a {
   line-height: 0;
 }
 
-main .columns .column-picture a:hover img,
-main .columns .column-picture a:focus img {
-  filter: brightness(1.1);
-  transform: scale(1.05);
-}
-
 main .dark-theme .columns p {
   color: var(--color-white);
 }

--- a/templates/consonant/blocks/columns/columns.js
+++ b/templates/consonant/blocks/columns/columns.js
@@ -19,16 +19,28 @@ function lazyDecorteVideoForColumn($column, $a) {
   if (!$a || (!$a.href.endsWith('.mp4') && !$a.href.startsWith('https://www.youtube.com/watch') && !$a.href.startsWith('https://youtu.be/'))) return;
   const decorateVideo = () => {
     if ($column.classList.contains('column-picture')) return;
-    let video = null;
+    let youtube = null;
+    let mp4 = null;
     if ($a.href.endsWith('.mp4')) {
-      video = transformLinkToAnimation($a);
+      mp4 = transformLinkToAnimation($a);
     } else if ($a.href.startsWith('https://www.youtube.com/watch') || $a.href.startsWith('https://youtu.be/')) {
-      video = transformLinkToYoutubeEmbed($a);
+      youtube = transformLinkToYoutubeEmbed($a);
     }
     $column.innerHTML = '';
-    if (video) {
-      $column.appendChild(video);
+    if (youtube) {
       $column.classList.add('column-picture');
+      $column.appendChild(youtube);
+    } else if (mp4) {
+      $column.classList.add('column-picture');
+      const $row = $column.closest('.columns-row');
+      const $cta = $row.querySelector('.button');
+      if ($cta) {
+        const a = createTag('a', { href: $cta.href, title: $cta.title });
+        $column.appendChild(a);
+        a.appendChild(mp4);
+      } else {
+        $column.appendChild(mp4);
+      }
     }
   };
   const addIntersectionObserver = (block) => {

--- a/templates/consonant/blocks/columns/columns.js
+++ b/templates/consonant/blocks/columns/columns.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
-  isNodeName,
+  createTag,
   transformLinkToAnimation,
   transformLinkToYoutubeEmbed,
 } from '../../consonant.js';
@@ -71,12 +71,27 @@ export default function decorate($block) {
     const $columns = Array.from($row.children);
     $columns.forEach(($column) => {
       $column.classList.add('column');
-      if (isNodeName($column.firstElementChild, 'picture') || isNodeName($column.firstElementChild.firstElementChild, 'picture')) {
-        $column.classList.add('column-picture');
-      }
       const $a = $column.querySelector('a');
-      if ($a && $a.href.startsWith('https://') && $a.closest('.column').childNodes.length === 1) {
+      if ($a && $a.closest('.column').childNodes.length === 1 && ($a.href.endsWith('.mp4') || $a.href.startsWith('https://www.youtube.com/watch') || $a.href.startsWith('https://youtu.be/'))) {
         lazyDecorteVideoForColumn($column, $a);
+      } else {
+        const $pic = $column.querySelector('picture:first-child:last-child');
+        if ($pic) {
+          $column.classList.add('column-picture');
+          const $cta = $row.querySelector('.button');
+          const $picParent = $pic.parentElement;
+          $column.innerHTML = '';
+          if ($picParent.tagName.toLowerCase() === 'a') {
+            $column.appendChild($picParent);
+            $picParent.appendChild($pic);
+          } else if ($cta) {
+            const a = createTag('a', { href: $cta.href, title: $cta.title });
+            $column.appendChild(a);
+            a.appendChild($pic);
+          } else {
+            $column.appendChild($pic);
+          }
+        }
       }
     });
   });

--- a/templates/consonant/blocks/columns/columns.js
+++ b/templates/consonant/blocks/columns/columns.js
@@ -35,7 +35,7 @@ function lazyDecorteVideoForColumn($column, $a) {
       const $row = $column.closest('.columns-row');
       const $cta = $row.querySelector('.button');
       if ($cta) {
-        const a = createTag('a', { href: $cta.href, title: $cta.title });
+        const a = createTag('a', { href: $cta.href, title: $cta.title, target: $cta.target });
         $column.appendChild(a);
         a.appendChild(mp4);
       } else {
@@ -97,7 +97,7 @@ export default function decorate($block) {
             $column.appendChild($picParent);
             $picParent.appendChild($pic);
           } else if ($cta) {
-            const a = createTag('a', { href: $cta.href, title: $cta.title });
+            const a = createTag('a', { href: $cta.href, title: $cta.title, target: $cta.target });
             $column.appendChild(a);
             a.appendChild($pic);
           } else {

--- a/templates/consonant/blocks/columns/columns.js
+++ b/templates/consonant/blocks/columns/columns.js
@@ -33,7 +33,7 @@ function lazyDecorteVideoForColumn($column, $a) {
     } else if (mp4) {
       $column.classList.add('column-picture');
       const $row = $column.closest('.columns-row');
-      const $cta = $row.querySelector('.button');
+      const $cta = $row.querySelector('.button.accent') ?? $row.querySelector('.button');
       if ($cta) {
         const a = createTag('a', {
           href: $cta.href, title: $cta.title, target: $cta.target, rel: $cta.rel,
@@ -92,7 +92,7 @@ export default function decorate($block) {
         const $pic = $column.querySelector('picture:first-child:last-child');
         if ($pic) {
           $column.classList.add('column-picture');
-          const $cta = $row.querySelector('.button');
+          const $cta = $row.querySelector('.button.accent') ?? $row.querySelector('.button');
           const $picParent = $pic.parentElement;
           $column.innerHTML = '';
           if ($picParent.tagName.toLowerCase() === 'a') {

--- a/templates/consonant/blocks/columns/columns.js
+++ b/templates/consonant/blocks/columns/columns.js
@@ -35,7 +35,9 @@ function lazyDecorteVideoForColumn($column, $a) {
       const $row = $column.closest('.columns-row');
       const $cta = $row.querySelector('.button');
       if ($cta) {
-        const a = createTag('a', { href: $cta.href, title: $cta.title, target: $cta.target });
+        const a = createTag('a', {
+          href: $cta.href, title: $cta.title, target: $cta.target, rel: $cta.rel,
+        });
         $column.appendChild(a);
         a.appendChild(mp4);
       } else {
@@ -97,7 +99,9 @@ export default function decorate($block) {
             $column.appendChild($picParent);
             $picParent.appendChild($pic);
           } else if ($cta) {
-            const a = createTag('a', { href: $cta.href, title: $cta.title, target: $cta.target });
+            const a = createTag('a', {
+              href: $cta.href, title: $cta.title, target: $cta.target, rel: $cta.rel,
+            });
             $column.appendChild(a);
             a.appendChild($pic);
           } else {

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -393,16 +393,14 @@ main .marquee.center .marquee-column:not(.marquee-image) {
     main .marquee.large .marquee-image {
         margin-left: 0;
         align-items: flex-start;
-    }    
+    }
 
+    main .marquee .background > div,
+    main .marquee .background img,
+    main .marquee .background video,
     main .marquee.large .background > div,
     main .marquee.large .background img,
-    main .marquee.large .background video {
-        max-height: unset;
-        width: 101%;
-        height: 100%;
-    }    
-
+    main .marquee.large .background video,
     main .marquee.small .background > div,
     main .marquee.small .background img,
     main .marquee.small .background video {
@@ -534,36 +532,11 @@ main .marquee.center .marquee-column:not(.marquee-image) {
         max-height: unset;
     }
 
-    main .marquee.large .background > div,
-    main .marquee.large .background img,
-    main .marquee.large .background video {
-        max-height: unset;
-        width: 101%;
-        height: 100%;
-    }
-
     /* small */
 
     main .marquee.small {
         min-height: var(--marquee-height-lg);
         display: flex;
-    }
-
-    main .marquee.small .background {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: 100%;
-        max-height: unset;
-    }
-
-    main .marquee.small .background > div,
-    main .marquee.small .background img,
-    main .marquee.small .background video {
-        max-height: unset;
-        width: 101%;
-        height: 100%;
     }
 
     main .marquee.small {

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -100,7 +100,7 @@ main .marquee .background video {
 
 main .marquee .background img,
 main .marquee .background video {
-    min-height: 180px;
+    min-height: 200px;
 }
 
 main .marquee > .background:last-child {
@@ -127,7 +127,6 @@ main .marquee .background video {
     width: 101%;
     transform: translateX(-0.5%);
     height: 100%;
-    min-height: 100%;
     object-fit: cover;
 }
 
@@ -154,6 +153,11 @@ main .marquee .background > div > p:not(:first-child):not(:empty) {
 main .marquee .marquee-image p,
 main .marquee .background p {
     font-size: var(--body-font-size-s);
+}
+
+main .marquee.large .background img,
+main .marquee.large .background video {
+    min-height: 200px;
 }
 
 main .marquee .marquee-image p {

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -413,7 +413,7 @@ main .marquee.center .marquee-column:not(.marquee-image) {
     main .marquee.small .background img,
     main .marquee.small .background video {
         max-height: unset;
-        width: 101%;
+        width: 100%;
         height: 100%;
     }
 }

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -417,7 +417,8 @@ main .marquee.center .marquee-column:not(.marquee-image) {
 /* laptop */
 
 @media screen and (min-width: 1000px) {
-    main .marquee {
+    main .marquee,
+    main .marquee:not(.large):not(.small):not(.empty-content) {
         min-height: var(--marquee-height-md);
     }
     

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -535,11 +535,6 @@ main .marquee.center .marquee-column:not(.marquee-image) {
     /* small */
 
     main .marquee.small {
-        min-height: var(--marquee-height-lg);
-        display: flex;
-    }
-
-    main .marquee.small {
         min-height: var(--marquee-height-sm);
     }
 

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -394,6 +394,22 @@ main .marquee.center .marquee-column:not(.marquee-image) {
         margin-left: 0;
         align-items: flex-start;
     }    
+
+    main .marquee.large .background > div,
+    main .marquee.large .background img,
+    main .marquee.large .background video {
+        max-height: unset;
+        width: 101%;
+        height: 100%;
+    }    
+
+    main .marquee.small .background > div,
+    main .marquee.small .background img,
+    main .marquee.small .background video {
+        max-height: unset;
+        width: 101%;
+        height: 100%;
+    }
 }
 
 /* laptop */

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -515,7 +515,6 @@ main .marquee.center .marquee-column:not(.marquee-image) {
         top: 0;
     }
 
-    main .marquee.large .background,
     main .marquee.large .background img,
     main .marquee.large .background video {
         max-height: unset;

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -515,6 +515,11 @@ main .marquee.center .marquee-column:not(.marquee-image) {
         top: 0;
     }
 
+    main .marquee.large .background {
+        width: 100%;
+        height: 100%;
+    }
+
     main .marquee.large .background img,
     main .marquee.large .background video {
         max-height: unset;

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -384,6 +384,10 @@ main .marquee.center .marquee-column:not(.marquee-image) {
         max-width: unset;
     }
 
+    main .marquee:not(.large):not(.small):not(.empty-content) {
+        min-height: var(--marquee-height-sm);
+    }
+
     /* large */
 
     main .marquee.large .marquee-column {

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -124,7 +124,7 @@ main .marquee.light .background a {
 }
 
 main .marquee .background video {
-    width: 101%;
+    min-width: 101%;
     transform: translateX(-0.5%);
     height: 100%;
     object-fit: cover;

--- a/templates/consonant/blocks/marquee/marquee.css
+++ b/templates/consonant/blocks/marquee/marquee.css
@@ -126,7 +126,7 @@ main .marquee.light .background a {
 main .marquee .background video {
     width: 101%;
     transform: translateX(-0.5%);
-    height: auto;
+    height: 100%;
     min-height: 100%;
     object-fit: cover;
 }
@@ -513,13 +513,12 @@ main .marquee.center .marquee-column:not(.marquee-image) {
         position: absolute;
         left: 0;
         top: 0;
-    }
-
-    main .marquee.large .background {
         width: 100%;
         height: 100%;
+        max-height: unset;
     }
 
+    main .marquee.large .background > div,
     main .marquee.large .background img,
     main .marquee.large .background video {
         max-height: unset;
@@ -528,6 +527,28 @@ main .marquee.center .marquee-column:not(.marquee-image) {
     }
 
     /* small */
+
+    main .marquee.small {
+        min-height: var(--marquee-height-lg);
+        display: flex;
+    }
+
+    main .marquee.small .background {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        max-height: unset;
+    }
+
+    main .marquee.small .background > div,
+    main .marquee.small .background img,
+    main .marquee.small .background video {
+        max-height: unset;
+        width: 101%;
+        height: 100%;
+    }
 
     main .marquee.small {
         min-height: var(--marquee-height-sm);

--- a/templates/consonant/consonant.js
+++ b/templates/consonant/consonant.js
@@ -255,10 +255,17 @@ export function decorateBlocks($main) {
     }
     if (!section) return;
 
+    // Hide invisible blocks
     const invisBlocks = ['template', 'metadata', 'section-metadata'];
     invisBlocks.forEach((invisBlockName) => {
       if (blockName === invisBlockName) $block.classList.add('hidden');
     });
+    const children = Array.from(section.querySelectorAll(':scope > div > *'));
+    let hideSection = true;
+    children.forEach((child) => {
+      if (!child.classList.contains('hidden')) hideSection = false;
+    });
+    if (hideSection) section.remove();
 
     // Wrap text-nodes or <a>-nodes in a <p> if they are alone...
     const divs = Array.from($block.querySelectorAll(':scope > div div'));


### PR DESCRIPTION
Feature request on Airtable:
![image](https://user-images.githubusercontent.com/62023521/164744829-950abf73-a36b-4621-9fa9-b7ffcb353944.png)
"With a large featured image many users will try clicking on the image itself expecting it to link. Can we add behavior so that for featured pods, the image links to the same page as the CTA button?
IF there are multiple CTAs it should link to the primary CTA. If there is no primary CTA but there are two buttons, then it should link tot he first one.
IF there is no button then no link on image."

### Column image behavior: ###
- If the image is surrounded by a link, use that link.
- If the image is not surrounded by a link, look for the primary CTA or first CTA in the same row and use that as a link.
- If there is no CTA, the image has no link.

Test URL:
https://columns--pages--webistry-development.hlx.page/stock/en/artisthub/drafts/block-test
https://columns--pages--webistry-development.hlx.page/stock/en/artisthub/drafts/block-library
- Tested the 3 criteria above.
- Tested that the links work properly, and don't affect the style of the column in all 3 block options (Small, Med/default, Large).
- Tested that it works with .mp4 'gifs' and lazy-loading those.
- Tested that it didn't break the YouTube videos.

Other fixes:
- Removed the white space from hidden sections
- Adjusted Marquee block to prevent horizontal scroll and tested all options to make sure the heights are correct.
https://columns--pages--webistry-development.hlx.page/stock/en/artisthub/get-inspired/creative-trends/design-trend-otherworldly-visions-call-for-stock-content