### PR TITLE
Redirect to step 1, if no step index specified.

### DIFF
--- a/templates/default/default.js
+++ b/templates/default/default.js
@@ -1061,7 +1061,6 @@ function setLCPTrigger(doc, postLCP) {
 }
 
 export async function decorateDefault($main) {
-  loadCSS('/pages/styles/default.css', true, true);
   decorateTables();
   wrapSections('main>div');
   decorateBlocks($main);

--- a/templates/learn/learn.js
+++ b/templates/learn/learn.js
@@ -212,6 +212,12 @@ async function decorateStep() {
   // $content.appendChild($video);
 
   const stepIndex = (+window.location.search.substring(1).split('&')[0]) - 1;
+
+  // redirect to step 1, if no step index specified.
+  if(stepIndex < 0) {
+    window.location = window.location.origin + window.location.pathname + '?1';
+  }
+
   const steps = await fetchSteps();
   const currentStep = steps[stepIndex];
 

--- a/templates/mobile-awareness/mobile-awareness.js
+++ b/templates/mobile-awareness/mobile-awareness.js
@@ -29,7 +29,6 @@ import decorateAppPage from './decorators/decorateAppPage.js';
 import setUpBranch from './scripts/branch.js';
 
 export default async function decoratePage() {
-  loadCSS('/pages/styles/default.css', true, true);
   loadURLParams();
   decorateNav();
   decorateGeneral();


### PR DESCRIPTION
Resolving Issue ticket:
[MWPW-111004](https://jira.corp.adobe.com/browse/MWPW-111004)

- Added redirect via JS since this is more like logical bug from learn module.
- Also removed default.css importing code from two places since it doesn't exist it will help 404 issue. 
(This is not related to ticket) - example page: https://pages.adobe.com/documentation/en/authoring-pages

Testing Pages:
https://main--pages--adobe.hlx.live/creativecloud/es/photography-plan/lightroom-classic/crop-emphasis/step
https://step-redirect--pages--adobe.hlx.live/creativecloud/es/photography-plan/lightroom-classic/crop-emphasis/step

https://main--pages--adobe.hlx.live/creativecloud/es/photography-plan/lightroom-classic/sunrise-pop/step
https://step-redirect--pages--adobe.hlx.live/creativecloud/es/photography-plan/lightroom-classic/sunrise-pop/step

https://main--pages--adobe.hlx.live/creativecloud/pt/photography-plan/lightroom-classic/color-grading/crop-emphasis/step
https://step-redirect--pages--adobe.hlx.live/creativecloud/pt/photography-plan/lightroom-classic/color-grading/crop-emphasis/step

https://main--pages--adobe.hlx.live/creativecloud/pt/photography-plan/lightroom-classic/crop-emphasis/step
https://step-redirect--pages--adobe.hlx.live/creativecloud/pt/photography-plan/lightroom-classic/crop-emphasis/step

https://main--pages--adobe.hlx.live/creativecloud/pt/photography-plan/lightroom-classic/sunrise-pop/step
https://step-redirect--pages--adobe.hlx.live/creativecloud/pt/photography-plan/lightroom-classic/sunrise-pop/step
