### PR TITLE
bring the default.css back with corrected path.

### DIFF
--- a/templates/default/default.js
+++ b/templates/default/default.js
@@ -1061,6 +1061,7 @@ function setLCPTrigger(doc, postLCP) {
 }
 
 export async function decorateDefault($main) {
+  loadCSS('/templates/default/default.css', true, true);
   decorateTables();
   wrapSections('main>div');
   decorateBlocks($main);

--- a/templates/mobile-awareness/mobile-awareness.js
+++ b/templates/mobile-awareness/mobile-awareness.js
@@ -29,6 +29,7 @@ import decorateAppPage from './decorators/decorateAppPage.js';
 import setUpBranch from './scripts/branch.js';
 
 export default async function decoratePage() {
+  loadCSS('/templates/default/default.css', true, true);
   loadURLParams();
   decorateNav();
   decorateGeneral();


### PR DESCRIPTION
[Jasper](https://adobedotcom.slack.com/team/WC7QCQPV2), asks where the default.css went:
"Hi all! I developed the template for the Growth squad's [Apps In Your Plan](https://pages.adobe.com/creativecloud/en/mobile-apps-in-your-plan/cpp) discovery page a few months back, and all was well. Now, however, the page is missing the base Adobe stylesheet.
My code was pointing to https://pages.adobe.com/pages/styles/default.css , but that file has clearly been moved or deleted since. (see https://github.com/adobe/pages/tree/main/pages/styles)
Can anyone point me to where that file went?"

I see the footer is broken due to missing default.css.

Current:
https://main--pages--adobe.hlx.page/creativecloud/en/mobile-apps-in-your-plan/cpp

Test:
https://default-css--pages--adobe.hlx.page/creativecloud/en/mobile-apps-in-your-plan/cpp

