### PR TITLE
fix(consonant-template): fix extra spacing between p and headers

### DIFF
--- a/templates/consonant/consonant.css
+++ b/templates/consonant/consonant.css
@@ -174,6 +174,10 @@ p {
   padding-bottom: 12px;
 }
 
+p:last-child {
+  padding-bottom: 0;
+}
+
 p:empty {
   padding: 0;
 }


### PR DESCRIPTION
The artisthub team noticed extra / inconsistent spacing above headers, this should fix it.

Test urls:

[before](https://main--pages--adobe.hlx.page/stock/en/artisthub/learn/draft-of-getting-powerfully-playful-with-the-zamurovic-brothers) / [after](https://consonant-p--pages--webistry-development.hlx.page/stock/en/artisthub/learn/draft-of-getting-powerfully-playful-with-the-zamurovic-brothers)