### PR TITLE
fix(advocates): fix 2 visual bugs

### DIFF
--- a/templates/stock-advocates/stock-advocates.css
+++ b/templates/stock-advocates/stock-advocates.css
@@ -748,7 +748,8 @@ main .embed-internal-accessibility a {
     margin-block-end: 0px;
 }
 
-.embed-internal-fundsection>div:first-of-type picture,img {
+.embed-internal-fundsection>div:first-of-type picture,
+.embed-internal-fundsection>div:first-of-type picture img {
   object-fit: cover;
   width: 100%;
   height: 100%;
@@ -1404,9 +1405,20 @@ main .columns ul {
 }
 
 .columns>div>div.image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+}
+
+.columns>div.padded>div.image img {
+  object-fit: contain;
+  height: auto;
+  object-position: top; 
+}
+
+.columns>div.padded>div.image .image-bleed {
+  height: auto;
 }
 
 .columns>div>div.image p:empty {

--- a/templates/stock-advocates/stock-advocates.css
+++ b/templates/stock-advocates/stock-advocates.css
@@ -1389,6 +1389,7 @@ main .columns ul {
 .columns>div.padded>div.image img {
   padding: 40px 40px 100px 40px;
 }
+
 .columns>div.padded>div.image p.caption {
   color: black;
   text-align: left;


### PR DESCRIPTION
Fix 2 visual bugs:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/62023521/187704373-9358d591-a2a3-4082-970b-498d441f0acd.png">
- In all the pages the St logo on the top left side of the page is distorted on the ST black square
- In Veterans return page - the image grid is broken.

Test url:
- Homepage ( [Before](https://main--pages--adobe.hlx.page/stock/en/advocates/) / [After](https://main--pages--webistry-development.hlx.page/stock/en/advocates/) )
- Veterans page ( [Before](https://main--pages--adobe.hlx.page/stock/en/advocates/veterans-return) / [After](https://main--pages--webistry-development.hlx.page/stock/en/advocates/veterans-return) )