### PR TITLE
fix(Header): Ensure Acessibility

### DIFF
--- a/templates/consonant/blocks/header/header.js
+++ b/templates/consonant/blocks/header/header.js
@@ -134,7 +134,6 @@ function dropdownEvents($dropdown) {
       openDropdown($dropdown);
     } else {
       closeDropdown($dropdown);
-      $link.addEventListener('click', ensureAccessibility);
     }
   });
   // Ensure accessibility
@@ -151,7 +150,6 @@ function dropdownEvents($dropdown) {
     if (!$dropdown.contains(e.relatedTarget) && !$chevron.contains(e.relatedTarget)
     && $dropdown !== e.relatedTarget && $chevron !== e.relatedTarget && e.relatedTarget !== null) {
       closeDropdown($dropdown);
-      $link.addEventListener('click', ensureAccessibility);
     }
   });
 
@@ -164,7 +162,6 @@ function dropdownEvents($dropdown) {
   $dropdown.addEventListener('mouseleave', () => {
     if (window.innerWidth > 900) {
       closeDropdown($dropdown);
-      $link.addEventListener('click', ensureAccessibility);
     }
   }, false);
 }

--- a/templates/consonant/blocks/header/header.js
+++ b/templates/consonant/blocks/header/header.js
@@ -126,6 +126,7 @@ function openDropdown($dropdown) {
 
 function dropdownEvents($dropdown) {
   const $chevron = $dropdown.querySelector('.chevron');
+  const $link = $dropdown.querySelector(':scope > a:any-link');
 
   // Toggle dropdown if they click on chevron
   $chevron.addEventListener('click', () => {
@@ -133,24 +134,24 @@ function dropdownEvents($dropdown) {
       openDropdown($dropdown);
     } else {
       closeDropdown($dropdown);
+      $link.addEventListener('click', ensureAccessibility);
     }
   });
   // Ensure accessibility
-  const $link = $dropdown.querySelector(':scope > a:any-link');
-  if ($link) {
-    $link.addEventListener('click', (event) => {
-      if (document.body.classList.contains('menu-open') && !$dropdown.classList.contains('dropdown-open')) {
-        event.preventDefault();
-        $chevron.click();
-      }
-    });
-  }
+  const ensureAccessibility = (event) => {
+    if (document.body.classList.contains('menu-open') && !$dropdown.classList.contains('dropdown-open')) {
+      event.preventDefault();
+      $chevron.click();
+    }
+  };
+  if ($link) $link.addEventListener('click', ensureAccessibility);
 
   // Close dropdown if they focus out
   $dropdown.addEventListener('focusout', (e) => {
     if (!$dropdown.contains(e.relatedTarget) && !$chevron.contains(e.relatedTarget)
     && $dropdown !== e.relatedTarget && $chevron !== e.relatedTarget && e.relatedTarget !== null) {
       closeDropdown($dropdown);
+      $link.addEventListener('click', ensureAccessibility);
     }
   });
 
@@ -163,6 +164,7 @@ function dropdownEvents($dropdown) {
   $dropdown.addEventListener('mouseleave', () => {
     if (window.innerWidth > 900) {
       closeDropdown($dropdown);
+      $link.addEventListener('click', ensureAccessibility);
     }
   }, false);
 }

--- a/templates/consonant/blocks/header/header.js
+++ b/templates/consonant/blocks/header/header.js
@@ -126,6 +126,7 @@ function openDropdown($dropdown) {
 
 function dropdownEvents($dropdown) {
   const $chevron = $dropdown.querySelector('.chevron');
+  const $link = $dropdown.querySelector(':scope > a:any-link');
 
   // Toggle dropdown if they click on chevron
   $chevron.addEventListener('click', () => {
@@ -133,14 +134,24 @@ function dropdownEvents($dropdown) {
       openDropdown($dropdown);
     } else {
       closeDropdown($dropdown);
+      $link.addEventListener('click', ensureAccessibility);
     }
   });
+  // Ensure accessibility
+  const ensureAccessibility = (event) => {
+    if (document.body.classList.contains('menu-open') && !$dropdown.classList.contains('dropdown-open')) {
+      event.preventDefault();
+      $chevron.click();
+    }
+  };
+  if ($link) $link.addEventListener('click', ensureAccessibility);
 
   // Close dropdown if they focus out
   $dropdown.addEventListener('focusout', (e) => {
     if (!$dropdown.contains(e.relatedTarget) && !$chevron.contains(e.relatedTarget)
     && $dropdown !== e.relatedTarget && $chevron !== e.relatedTarget && e.relatedTarget !== null) {
       closeDropdown($dropdown);
+      $link.addEventListener('click', ensureAccessibility);
     }
   });
 
@@ -153,6 +164,7 @@ function dropdownEvents($dropdown) {
   $dropdown.addEventListener('mouseleave', () => {
     if (window.innerWidth > 900) {
       closeDropdown($dropdown);
+      $link.addEventListener('click', ensureAccessibility);
     }
   }, false);
 }

--- a/templates/consonant/blocks/header/header.js
+++ b/templates/consonant/blocks/header/header.js
@@ -135,6 +135,16 @@ function dropdownEvents($dropdown) {
       closeDropdown($dropdown);
     }
   });
+  // Ensure accessibility
+  const $link = $dropdown.querySelector(':scope > a:any-link');
+  if ($link) {
+    $link.addEventListener('click', (event) => {
+      if (document.body.classList.contains('menu-open') && !$dropdown.classList.contains('dropdown-open')) {
+        event.preventDefault();
+        $chevron.click();
+      }
+    });
+  }
 
   // Close dropdown if they focus out
   $dropdown.addEventListener('focusout', (e) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The page menu on mobile seemed less user-accessible than I planned (not clicking directly on the chevron would NOT toggle the dropdown like the user would plan to do, and would go straight to the link instead. Now, the first click will open the dropdown, and the 2nd click will go to the link.

Test URLs:
- Before: https://pages.adobe.com/stock/en/artisthub/community/stock-mentors
- After: https://main--pages--webistry-development.hlx.page/stock/en/artisthub/community/stock-mentors?lighthouse=off

I tested with each: keyboard, touch phone, mouse. The mobile menu is now 100% more accessible!


Edit: for Franklin-bot: https://ensure-accessibility--pages--webistry-development.hlx.live/stock/en/artisthub/community/stock-mentors?lighthouse=off