### PR TITLE
fix: tl template fix

### DIFF
--- a/templates/tl/styles.css
+++ b/templates/tl/styles.css
@@ -535,7 +535,8 @@ footer p:after {
     line-height: 0;
   }
 
-  header .icon img {
+  header .icon img,
+  header img.icon {
     position: relative;
     /* top: 2px; */
     width: 40px;


### PR DESCRIPTION
Broken icon on: https://pages.adobe.com/illustrator/en/tl/thr-illustration-home/

After:
- https://v7-tl--pages--adobe.hlx.page/illustrator/en/tl/thr-illustration-home/

This page is correct but is also using the tl template (here only to verify potential regressions)

Before:
- https://main--pages--adobe.hlx.page/photoshop/en/14-day-trial/design/
After:
- https://v7-tl--pages--adobe.hlx.page/photoshop/en/14-day-trial/design/